### PR TITLE
Attach deposit to create and show job frontend

### DIFF
--- a/frontend/src/components/contracts/ContractItem.tsx
+++ b/frontend/src/components/contracts/ContractItem.tsx
@@ -11,10 +11,8 @@ interface IJobDataItemProps {
   job: IJobData;
 }
 
-const tokenName = process.env.REACT_APP_PAYMENT_TOKEN_NAME || '';
-
 const ContractItem: React.FC<IJobDataItemProps> = ({ job }) => {
-  const { id, title, bounty, deposit, state } = job;
+  const { id, title, bounty, requiredDeposit, state } = job;
 
   return (
     <li
@@ -35,14 +33,14 @@ const ContractItem: React.FC<IJobDataItemProps> = ({ job }) => {
                     className="mr-2 h-5 w-5 text-green-500"
                     aria-hidden="true"
                   />
-                  {bounty} {tokenName} Bounty
+                  {bounty} {job.paymentTokenName} Bounty
                 </p>
                 <p className="text-md mt-1 flex items-center truncate font-bold text-gray-700">
                   <OutlineCashIcon
                     className="mr-2 h-5 w-5 text-green-500"
                     aria-hidden="true"
                   />
-                  {deposit || '0'} {tokenName} Buy-In
+                  {requiredDeposit || '0'} {job.paymentTokenName} Buy-In
                 </p>
               </div>
             </div>

--- a/frontend/src/components/create-contract/PaymentSummary.tsx
+++ b/frontend/src/components/create-contract/PaymentSummary.tsx
@@ -10,25 +10,25 @@ const PaymentSummary = ({
   const token = tokenName || process.env.REACT_APP_PAYMENT_TOKEN_NAME || '';
 
   const bounty = data.bounty ? parseInt(data.bounty) : 0;
-  const buyIn = bounty * 0.1;
+  const deposit = data.deposit ? parseInt(data.deposit) : 0;
 
-  const totalPayout = bounty + buyIn;
+  const totalPayout = bounty + deposit;
 
   return (
     <>
       <p className="text-lg font-medium leading-6">Summary</p>
       <p className="mt-1 text-sm font-normal leading-5">
-        {bounty} {token} Bounty + {buyIn} {token} Buy-In
+        {bounty} {token} Bounty + {deposit} {token} Buy-In
       </p>
       <p className="text-lg font-semibold leading-7">
         {totalPayout} {token} Total Payout
       </p>
-      <button
-        type="button"
+      <a
+        href="https://engineerdao.notion.site/How-It-Works-6ce13129b9244abf981b41666b90797e"
         className="focus:outline-none mt-3 inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
       >
         How It Works
-      </button>
+      </a>
     </>
   );
 };

--- a/frontend/src/components/data-table/DataTable.tsx
+++ b/frontend/src/components/data-table/DataTable.tsx
@@ -17,6 +17,7 @@ interface IAttachment {
 
 const DataTable: React.FC<IDataTableProps> = (props) => {
   const { contract } = props;
+  const tokenName = process.env.REACT_APP_PAYMENT_TOKEN_NAME || '';
 
   return (
     <div className="overflow-hidden bg-white shadow sm:rounded-lg">
@@ -50,15 +51,21 @@ const DataTable: React.FC<IDataTableProps> = (props) => {
           />
           <DataTableItemCurrency
             label="Bounty"
-            value={{ crypto_value: contract.bounty, crypto_suffix: 'ETH' }}
+            value={{ crypto_value: contract.bounty, crypto_suffix: tokenName }}
           />
           <DataTableItemCurrency
-            label={mockContractData[10].label}
-            value={mockContractData[10].value as any}
+            label="Buy-In"
+            value={{
+              crypto_value: contract.requiredDeposit,
+              crypto_suffix: tokenName,
+            }}
           />
           <DataTableItemActions
-            label={mockContractData[11].label}
-            value={mockContractData[11].value as any}
+            label="Total Payout"
+            value={{
+              crypto_value: contract.bounty + contract.requiredDeposit,
+              crypto_suffix: tokenName,
+            }}
           />
         </dl>
       </div>

--- a/frontend/src/components/data-table/row-types/DataTableItemActions.tsx
+++ b/frontend/src/components/data-table/row-types/DataTableItemActions.tsx
@@ -16,7 +16,11 @@ const DataTableItemActions: React.FC<IDataTableItemActions> = (props) => {
             <span className="font-bold">
               {crypto_value} {crypto_suffix}
             </span>
-            &nbsp;({fiat_value} {fiat_suffix})
+            {fiat_value && (
+              <>
+                &nbsp;({fiat_value} {fiat_suffix})
+              </>
+            )}
           </div>
           <StartJobButton />
         </div>

--- a/frontend/src/components/data-table/row-types/DataTableItemCurrency.tsx
+++ b/frontend/src/components/data-table/row-types/DataTableItemCurrency.tsx
@@ -15,7 +15,11 @@ const DataTableItemCurrency: React.FC<IDataTableItemCurrency> = (props) => {
             <span className="font-bold">
               {crypto_value} {crypto_suffix}
             </span>
-            &nbsp;({fiat_value} {fiat_suffix})
+            {fiat_value && (
+              <>
+                &nbsp;({fiat_value} {fiat_suffix})
+              </>
+            )}
           </div>
         </div>
       </dd>

--- a/frontend/src/components/smart-contracts/hooks/useJob.ts
+++ b/frontend/src/components/smart-contracts/hooks/useJob.ts
@@ -9,6 +9,7 @@ import {
 import { ISmartContractState } from 'interfaces/ISmartContractState';
 import { useEffect, useState } from 'react';
 import { fetchIpfsMetaData } from 'services/ipfs';
+import { formatIntegerPercentage } from 'utils/number';
 
 enum CacheKeys {
   JOB = 'job',
@@ -41,6 +42,8 @@ const assembleJob = (
     deposit: BigNumber.from(jobContractData.deposit)
       .div(ethers.constants.WeiPerEther)
       .toNumber(),
+    depositPct: jobContractData.depositPct.toNumber(),
+    formattedDepositPct: formatIntegerPercentage(jobContractData.depositPct),
     startTime: BigNumber.from(jobContractData.startTime).toNumber(),
     completedTime: BigNumber.from(jobContractData.completedTime).toNumber(),
     closedBySupplier: jobContractData.closedBySupplier,

--- a/frontend/src/components/smart-contracts/hooks/useJob.ts
+++ b/frontend/src/components/smart-contracts/hooks/useJob.ts
@@ -57,6 +57,9 @@ const assembleJob = (
     identity: jobMetaData.identity,
     acceptanceTests: jobMetaData.acceptanceTests,
     endDate: jobMetaData.endDate,
+    requiredDeposit: jobMetaData.deposit,
+
+    paymentTokenName: process.env.REACT_APP_PAYMENT_TOKEN_NAME || '',
   };
 
   return job;

--- a/frontend/src/components/smart-contracts/modals/PostJobModal.tsx
+++ b/frontend/src/components/smart-contracts/modals/PostJobModal.tsx
@@ -1,12 +1,13 @@
-import { TransactionModal } from 'components/smart-contracts/modals/TransactionModal';
 import { useSmartContracts } from 'components/smart-contracts/hooks/useSmartContracts';
+import { TransactionModal } from 'components/smart-contracts/modals/TransactionModal';
 import { SmartContractAddresses } from 'components/smart-contracts/SmartContractAddresses';
 import { useWallet } from 'components/wallet/useWallet';
 import { ContractReceipt, ethers } from 'ethers';
 import { ITransactionModalProps } from 'interfaces/ITransactionModalProps';
-import { ICreateContractForm } from '../../create-contract/ICreateContractForm';
-import { pinIpfsMetaData } from 'services/ipfs';
 import React, { useEffect, useState } from 'react';
+import { pinIpfsMetaData } from 'services/ipfs';
+import { buildIntegerPercentage } from 'utils/number';
+import { ICreateContractForm } from '../../create-contract/ICreateContractForm';
 import { Modal } from '../../modals/Modal';
 
 interface IProps extends ITransactionModalProps {
@@ -25,8 +26,9 @@ export const PostJobModal = (props: IProps) => {
   // the logic called to initiate the transaction
   const callContract = async () => {
     const bountyWei = ethers.utils.parseUnits(formData.bounty.toString());
+    const depositWei = ethers.utils.parseUnits(formData.deposit.toString());
 
-    const depositPct = 1000; // TODO - hook this up to the form value
+    const depositPct = buildIntegerPercentage(depositWei, bountyWei);
 
     return contracts.Job.postJob(
       SmartContractAddresses.PaymentToken,

--- a/frontend/src/interfaces/IJobData.ts
+++ b/frontend/src/interfaces/IJobData.ts
@@ -39,4 +39,7 @@ export interface IJobData extends IJobMetaData {
   closedBySupplier: boolean;
   closedByEngineer: boolean;
   state: JobState;
+
+  paymentTokenName: string;
+  requiredDeposit: number;
 }

--- a/frontend/src/interfaces/IJobData.ts
+++ b/frontend/src/interfaces/IJobData.ts
@@ -7,6 +7,7 @@ export interface IJobSmartContractData {
   bounty: BigNumber;
   engineer: string;
   deposit: BigNumber;
+  depositPct: BigNumber;
   startTime: BigNumber;
   completedTime: BigNumber;
   closedBySupplier: boolean;
@@ -31,6 +32,8 @@ export interface IJobData extends IJobMetaData {
   supplier: string;
   engineer?: string;
   bounty: number;
+  depositPct: number;
+  formattedDepositPct: string;
   startTime?: number;
   completedTime?: number;
   closedBySupplier: boolean;

--- a/frontend/src/utils/number.ts
+++ b/frontend/src/utils/number.ts
@@ -1,0 +1,23 @@
+import { BigNumber, BigNumberish } from 'ethers';
+
+// percentages are calculated using integer math in the smart contract
+//  50% is 5,000, 100% is 10,000
+export const BASE_PERCENT = 10000;
+
+// returns an integer between 0 and 10,000 that represents a percentage
+export const buildIntegerPercentage = (
+  numerator: BigNumberish,
+  denominator: BigNumberish
+): BigNumber => {
+  return BigNumber.from(numerator).mul(BASE_PERCENT).div(denominator);
+};
+
+// formats an integer percentage
+//  converts 5,000 to '50'
+export const formatIntegerPercentage = (integerPct: BigNumberish): string => {
+  const num = (BigNumber.from(integerPct).toNumber() * 100) / BASE_PERCENT;
+  return num.toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 0,
+  });
+};


### PR DESCRIPTION
Hooks up the entered deposit (buy-in) percentage to the smart contract.

Also shows the bounty and deposit in some more places on the output.

Adds `requiredDeposit` as a field from the job metadata.
Hooks up "How it Works" button

<img width="641" alt="image" src="https://user-images.githubusercontent.com/51414/154803873-222eb18e-ade6-4bd6-a7cb-cd15d8c00334.png">
