### PR TITLE
Fix: Handle undefined entries in IPFS metadata validation

### DIFF
--- a/backend/services/schema/transform.ts
+++ b/backend/services/schema/transform.ts
@@ -34,9 +34,9 @@ export const transformJobToIPFS = (
     description: formData.description,
     contactInformation: formData.contactInformation,
     acceptanceCriteria: formData.acceptanceCriteria,
-    labels: transformLabelsToIpfsData(formData.labels),
-    identity: transformLabelsToIpfsData(formData.identity),
-    acceptanceTests: transformLabelsToIpfsData(formData.acceptanceTests),
+    labels: transformLabelsToIpfsData(formData.labels || []),
+    identity: transformLabelsToIpfsData(formData.identity || []),
+    acceptanceTests: transformLabelsToIpfsData(formData.acceptanceTests || []),
     endDate: formData.endDate,
     version: CURRENT_SCHEMA_VERSION,
   };


### PR DESCRIPTION
IPFS validation was already in place.  This just fixes a small undefined error when validating.

Stacked on #85 

Closes #87 

