### PR TITLE
Move job provider above SingleContract component

### DIFF
--- a/frontend/src/components/Content.tsx
+++ b/frontend/src/components/Content.tsx
@@ -1,12 +1,13 @@
 import { MenuIcon } from '@heroicons/react/outline';
+import { JobProvider } from 'components/smart-contracts/JobProvider';
 import { Route, Switch } from 'react-router-dom';
 import { SectionPath } from '../enums/admin/Sections';
 import Community from '../pages/Community';
 import Contracts from '../pages/Contracts';
+import { CreateContract } from '../pages/CreateContract';
 import Dashboard from '../pages/Dashboard';
 import { MyContracts } from '../pages/MyContracts';
 import SingleContract from '../pages/SingleContract';
-import { CreateContract } from '../pages/CreateContract';
 import Testing from '../pages/Testing';
 import { isTestingEnvironment } from '../utils/testing';
 
@@ -46,7 +47,9 @@ const Content = (props: IContent) => {
                   <Community />
                 </Route>
                 <Route path={SectionPath.contract}>
-                  <SingleContract />
+                  <JobProvider>
+                    <SingleContract />
+                  </JobProvider>
                 </Route>
                 <Route path={SectionPath.createContract} exact>
                   <CreateContract />

--- a/frontend/src/pages/SingleContract.tsx
+++ b/frontend/src/pages/SingleContract.tsx
@@ -11,7 +11,6 @@ import {
   useAccountIsJobContractDisputeResolver,
   useJob,
 } from 'components/smart-contracts/hooks/useJob';
-import { JobProvider } from 'components/smart-contracts/JobProvider';
 import { useWallet } from 'components/wallet/useWallet';
 import { JobState } from 'enums/JobState';
 import React from 'react';
@@ -28,7 +27,7 @@ const SingleContract: React.FC = () => {
   const isEngineerOrSupplier = isEngineer || isSupplier;
 
   return (
-    <JobProvider>
+    <>
       <SingleContractHeading />
       <SingleContractData />
       {job?.state === JobState.Started && isEngineer && <CompleteJobForm />}
@@ -43,7 +42,7 @@ const SingleContract: React.FC = () => {
         <DisputeResolverForm />
       )}
       <ActivityFeed />
-    </JobProvider>
+    </>
   );
 };
 


### PR DESCRIPTION
JobProvider must be moved up in order to use `useJob` in the SingleContract component.