### PR TITLE
Replaces queryFilter events to resolve metadata ifps cid

### DIFF
--- a/backend/util/activityFeedSync.ts
+++ b/backend/util/activityFeedSync.ts
@@ -174,9 +174,13 @@ const storeLatestSyncedBlock = async (blockNumber: number) => {
 const buildEventMessageParameters = (untypedEvent: TypedEvent<any>) => {
   switch (untypedEvent.event) {
     case 'JobPosted':
+      const jobPostedEvent = untypedEvent as JobPostedEvent;
       return buildContractEvent(
         untypedEvent,
-        (untypedEvent as JobPostedEvent).args.jobId.toString()
+        jobPostedEvent.args.jobId.toString(),
+        {
+          metadataCid: jobPostedEvent.args.metadataCid,
+        }
       );
 
     case 'JobStarted':
@@ -244,11 +248,13 @@ const buildEventMessageParameters = (untypedEvent: TypedEvent<any>) => {
       );
 
     case 'JobReported':
+      const jobReportedEvent = untypedEvent as JobReportedEvent;
       return buildContractEvent(
         untypedEvent,
-        (untypedEvent as JobReportedEvent).args.jobId.toString(),
+        jobReportedEvent.args.jobId.toString(),
         {
-          metadataCid: (untypedEvent as JobReportedEvent).args.metadataCid,
+          metadataCid: jobReportedEvent.args.metadataCid,
+          reporter: jobReportedEvent.args.reporter,
         }
       );
 


### PR DESCRIPTION
Adds metadataCid and reporter to backend args for JobPosted and JobReportedEvents (respectively)
Uses firebase for metadataCid when possible
Uses firebase for reporter

fixes #192 